### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 klatexformula (4.1.0-2) UNRELEASED; urgency=medium
 
   * Update standards version to 4.5.1, no changes needed.
+  * Avoid explicitly specifying -Wl,--as-needed linker flag.
 
  -- Debian Janitor <janitor@jelmer.uk>  Mon, 06 Sep 2021 00:31:55 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+klatexformula (4.1.0-2) UNRELEASED; urgency=medium
+
+  * Update standards version to 4.5.1, no changes needed.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Mon, 06 Sep 2021 00:31:55 -0000
+
 klatexformula (4.1.0-1) unstable; urgency=medium
 
   * New upstream release.

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Build-Depends: cmake,
                qtbase5-dev-tools,
                qttools5-dev
 Build-Depends-Indep: doxygen, graphviz
-Standards-Version: 4.5.0
+Standards-Version: 4.5.1
 Vcs-Git: https://github.com/TobiasWinchen/klatexformula_debian.git
 Vcs-Browser: https://github.com/TobiasWinchen/klatexformula_debian
 Homepage: https://klatexformula.sourceforge.io/

--- a/debian/rules
+++ b/debian/rules
@@ -1,7 +1,6 @@
 #!/usr/bin/make -f
 
 export DEB_BUILD_MAINT_OPTIONS  = hardening=+all
-export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 


### PR DESCRIPTION
Fix some issues reported by lintian

* Update standards version to 4.5.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))

* Avoid explicitly specifying -Wl,--as-needed linker flag. ([debian-rules-uses-as-needed-linker-flag](https://lintian.debian.org/tags/debian-rules-uses-as-needed-linker-flag))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/klatexformula/38de81b6-faab-460f-a3b7-1daf15efb27f.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/56/413a933d04c544ba8ba79500986ab91b42f6db.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/a1/67c2682e63ba113827acfbf4fc551815c1f8a8.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/aa/aa6c79d9ce82bce60044b56e28b80d022a8b0e.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/ff/a1a646ebeae33210fc12d0d32fe243d1df2c28.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/6a/6690e378f74a709a090d4861e8e2ff026d6287.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/72/050febd7c4d27a4d89b0bbd6b767fcd4e1289f.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/83/2fefc02356b8abb6d5f054203f78d8d33adeac.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/d6/0739d99a3fae04f68c49f0464073255b597608.debug

No differences were encountered between the control files of package \*\*klatexformula\*\*
### Control files of package klatexformula-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-832fefc02356b8abb6d5f054203f78d8d33adeac-] {+a167c2682e63ba113827acfbf4fc551815c1f8a8+}

No differences were encountered between the control files of package \*\*libklatexformula4\*\*
### Control files of package libklatexformula4-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-6a6690e378f74a709a090d4861e8e2ff026d6287 d60739d99a3fae04f68c49f0464073255b597608-] {+aaaa6c79d9ce82bce60044b56e28b80d022a8b0e ffa1a646ebeae33210fc12d0d32fe243d1df2c28+}

No differences were encountered between the control files of package \*\*libklatexformula4-dev\*\*
### Control files of package libklatexformula4-dev-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-72050febd7c4d27a4d89b0bbd6b767fcd4e1289f-] {+56413a933d04c544ba8ba79500986ab91b42f6db+}

No differences were encountered between the control files of package \*\*libklatexformula4-doc\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/38de81b6-faab-460f-a3b7-1daf15efb27f/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/38de81b6-faab-460f-a3b7-1daf15efb27f/diffoscope)).
